### PR TITLE
Add asynchronous HTTP requests for images and games

### DIFF
--- a/src/core/async.lua
+++ b/src/core/async.lua
@@ -155,11 +155,9 @@ local function love_filesystem_sink(fname, callback)
   return function(chunk, err)
     if chunk then
       if not file then
-        print("opening", fname)
         file = love.filesystem.newFile(fname)
         file:open("w")
       end
-      print("writing", #chunk, "bytes")
       return file:write(chunk)
     else
       file:close()

--- a/src/core/async.lua
+++ b/src/core/async.lua
@@ -1,0 +1,178 @@
+local socket = require("socket")
+local ltn12 = require("ltn12")
+
+-- don't protect anything
+socket.protect = function(fn)
+  return fn
+end
+
+local http = require("socket.http")
+
+local function non_blocking_tcp()
+  local sock = socket.tcp()
+  sock:settimeout(0)
+
+  local function run_nonblock(func, ...)
+    while true do
+      local res = {
+        func(...)
+      }
+      if res[1] == nil and res[2] == "timeout" then
+        coroutine.yield("timeout", sock)
+      else
+        return unpack(res)
+      end
+    end
+  end
+
+  return setmetatable({
+    sock = sock,
+
+		-- don't allow timeout to be changed
+    settimeout = function()
+      return true
+    end,
+
+    send = function(self, ...)
+      return run_nonblock(self.sock.send, self.sock, ...)
+    end,
+
+    connect = function(self, ...)
+      return run_nonblock(self.sock.connect, self.sock, ...)
+    end,
+
+    receive = function(self, ...)
+      while true do
+        local msg, err, partial = self.sock:receive(...)
+        if err == "timeout" then
+          if partial and #partial > 0 then
+            return partial
+          else
+            coroutine.yield("timeout", sock)
+          end
+        else
+          return msg, err, partial
+        end
+      end
+    end
+  }, {
+    __index = function(self, name)
+      self[name] = function(self, ...)
+        return self.sock[name](self.sock, ...)
+      end
+      return self[name]
+    end
+  })
+end
+
+local socket_queue_mt = {
+  __index = {
+    request = function(self, url, sink)
+      local sock = non_blocking_tcp()
+      local co = coroutine.create(function()
+        http.request({
+          url = url,
+          sink = sink,
+          create = non_blocking_tcp
+        })
+        self.coroutines[coroutine.running()] = nil
+      end)
+      self.coroutines[co] = true
+    end,
+
+    requeue = function(self, sock)
+      local i
+      for oi, other in ipairs(self.sockets) do
+        if other == sock then
+          i = oi
+          break
+        end
+      end
+      if i then
+        sock = table.remove(self.sockets, i)
+        local co = self.sockets[sock]
+        self.coroutines[co] = true
+      end
+    end,
+
+    update = function(self)
+      for co in pairs(self.coroutines) do
+        local success, status, sock = coroutine.resume(co)
+        if not success then
+          if type(status) == "table" then
+            status = unpack(status)
+          end
+          error("Failed to resume coroutine: " .. tostring(status) .. "\n" .. debug.traceback(co))
+        end
+        if status == "timeout" then
+          table.insert(self.sockets, sock)
+          self.sockets[sock] = co
+          self.coroutines[co] = nil
+        end
+      end
+      if self.sockets[1] then
+        local read, write = socket.select(self.sockets, self.sockets, 0)
+        for _index_0 = 1, #read do
+          local sock = read[_index_0]
+          self:requeue(sock)
+        end
+        for _index_0 = 1, #write do
+          local sock = write[_index_0]
+          self:requeue(sock)
+        end
+      end
+    end
+  }
+}
+
+
+local function SocketQueue()
+  return setmetatable({
+    coroutines = { },
+    sockets = { }
+  }, socket_queue_mt)
+end
+
+
+local function callback_sink(fn)
+  local buffer = { }
+  return function(chunk, err)
+    if chunk == nil then
+      if err then
+        fn(nil, err)
+      else
+        fn(table.concat(buffer))
+      end
+    elseif chunk ~= "" then
+      table.insert(buffer, chunk)
+    end
+    return true
+  end
+end
+
+local function love_filesystem_sink(fname, callback)
+  local file
+  return function(chunk, err)
+    if chunk then
+      if not file then
+        print("opening", fname)
+        file = love.filesystem.newFile(fname)
+        file:open("w")
+      end
+      print("writing", #chunk, "bytes")
+      return file:write(chunk)
+    else
+      file:close()
+      if callback then
+        return callback()
+      end
+    end
+  end
+end
+
+
+return {
+  SocketQueue = SocketQueue,
+  love_filesystem_sink = love_filesystem_sink,
+  callback_sink = callback_sink
+}

--- a/src/core/remote.lua
+++ b/src/core/remote.lua
@@ -2,9 +2,14 @@ remote = {}
 
 remote.uri = "http://50.116.63.25/public/vapor/games.json"
 
-function remote.load()
+-- @param force_local don't check remote server for new file
+function remote.load(force_local)
 
-  r,e = http.request(remote.uri)
+  local r,r
+  if not force_local then
+    r,e = http.request(remote.uri)
+  end
+
   if e == 200 then
     print("games.json successfully updated.")
     love.filesystem.write("games.json",r)

--- a/src/core/remote.lua
+++ b/src/core/remote.lua
@@ -5,7 +5,7 @@ remote.uri = "http://50.116.63.25/public/vapor/games.json"
 -- @param force_local don't check remote server for new file
 function remote.load(force_local)
 
-  local r,r
+  local r,e
   if not force_local then
     r,e = http.request(remote.uri)
   end

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,6 +1,8 @@
 require("lib/json")
 async = require("core/async") -- this needs to be required before "socket.http"
 
+http = require("socket.http")
+
 local currently_downloading = {}
 
 function imgname(gameobj)
@@ -31,9 +33,9 @@ function dogame(gameobj)
     local url = gameobj.sources[gameobj.stable]
 
     currently_downloading[fn] = true
-    downloader:request(url, async.love_filesystem_sink(fn, function()
+    downloader:request(url, async.love_filesystem_sink(fn), function()
       currently_downloading[fn] = nil
-    end))
+    end)
   end
 end
 
@@ -86,9 +88,9 @@ function love.update(dt)
           -- download it!
           print("downloading " .. imgn)
           currently_downloading[imgn] = true
-          downloader:request(remote.data.games[selectindex].image, async.love_filesystem_sink(imgn, function()
+          downloader:request(remote.data.games[selectindex].image, async.love_filesystem_sink(imgn), function()
             currently_downloading[imgn] = nil
-          end))
+          end)
         end
       end
     end

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,6 +1,9 @@
 require("lib/json")
+async = require("core/async") -- this needs to be required before any "socket.http" requires
 
 http = require("socket.http")
+
+local currently_downloading = {}
 
 function imgname(gameobj)
   return gameobj.id..".png"
@@ -45,6 +48,8 @@ function love.load(args)
   settings = require("core/settings")
   remote = require("core/remote")
 
+  downloader = async.SocketQueue()
+
   remote.load()
   settings.load()
 
@@ -60,6 +65,8 @@ function love.load(args)
 end
 
 function love.update(dt)
+  downloader:update()
+
   local current = math.floor( ( love.mouse.getY() - settings.offset ) / settings.padding )
   if current >= 1 and current <= #remote.data.games then
     selectindex = current
@@ -68,25 +75,27 @@ function love.update(dt)
   end
   
   if selectindex then  
-  
-    local imgn = imgname(remote.data.games[selectindex])
-    if not love.filesystem.exists(imgn) then
-      r,e = http.request(remote.data.games[selectindex].image)
-      if e == 200 then
-        local success = love.filesystem.write(imgn,r)
-        if success then
-          print(imgn .. " downloaded successfully.")
+    if not images[selectindex] then
+      local current_index = selectindex
+      local imgn = imgname(remote.data.games[selectindex])
+
+      if not currently_downloading[imgn] then
+        if love.filesystem.exists(imgn) then
+          -- load the image
+          images[current_index] = love.graphics.newImage(imgn)
+        else
+          -- download it!
+          print("Downloading:", imgn)
+          currently_downloading[imgn] = true
+          downloader:request(remote.data.games[selectindex].image, async.love_filesystem_sink(imgn, function()
+            currently_downloading[imgn] = nil
+          end))
         end
       end
     end
-    
-    if not images[selectindex] then
-      images[selectindex] = love.graphics.newImage(imgn)
-    end
-
   end
-  
-  
+
+
 end
 
 function love.keypressed(key)
@@ -121,7 +130,7 @@ end
 function love.draw()
 
   love.graphics.setColor(colors.reset)
-  if selectindex then
+  if selectindex and images[selectindex] then
     love.graphics.draw(images[selectindex],settings.padding,settings.padding)
   else
     love.graphics.draw(nogame,settings.padding,settings.padding)

--- a/src/main.lua
+++ b/src/main.lua
@@ -85,7 +85,7 @@ function love.update(dt)
           images[current_index] = love.graphics.newImage(imgn)
         else
           -- download it!
-          print("Downloading:", imgn)
+          print("downloading " .. imgn)
           currently_downloading[imgn] = true
           downloader:request(remote.data.games[selectindex].image, async.love_filesystem_sink(imgn, function()
             currently_downloading[imgn] = nil


### PR DESCRIPTION
This replaces the blocking calls to `http.request` with non-blocking calls. I ended up implementing something similar to [Copas](http://keplerproject.github.io/copas/) that wraps the luasocket sockets and forces them to be non-blocking and runs the request through a coroutine.

`async.SocketQueue` is the data structure that manages all of our open connections. It has an update method that needs to be called every frame. It will trigger any work for any pending sockets. I've created an instance and stored it in a global called `downloader`.

In order to make a request you now do:

``` lua
downloader:request(url, ltn12_sink, callback)
```

`sink` is an ltn12 sink where the response of the request goes.

`callback` is an optional function that is called after the request is completely done. It receives no arguments.

I opted to use [ltn12](http://w3.impa.br/~diego/software/luasocket/old/luasocket-2.0-beta2/ltn12.html) similar to the built in HTTP module because it's pretty flexible. It allows us to stream files as they are downloaded, which is great for us because we might be downloading huge files and we don't want to take up a ton of memory and we can incrementally write to disk.

I created a special sink that writes to a file using `love.filesystem`. It's located at `async.love_filesystem_sink`.

So, to write to a file, we might do something like this:

``` lua
downloader:request("http://leafo.net", async.love_filesystem_sink("leafo_net.html"))
```

Try it out and tell me if you have any problems.
