### PR TITLE
Download button is hidden when opening Vapor

### DIFF
--- a/src/core/ui.lua
+++ b/src/core/ui.lua
@@ -73,6 +73,7 @@ end
 
 function ui.update_buttons()
   local gameobj = remote.data.games[selectindex]
+  ui.mainbutton.visible = selectindex~=nil
   if gameobj then
     local fn = vapor.fname(gameobj,gameobj.stable)
     if vapor.currently_downloading[fn] then


### PR DESCRIPTION
Hi,

Adding this single line makes the download button hidden (and unavailable) when opening Vapor.
As such, only the description "Welcome to Vapor" is visible.
The button becomes visible when the user clicks on any game in the list.

Regards,
Roland.
